### PR TITLE
[GPUDash] Fix incorrect VRAM values on GPUs over 4GB

### DIFF
--- a/GPUdash/GPUdash.ini
+++ b/GPUdash/GPUdash.ini
@@ -48,8 +48,8 @@ RegValue=PrimaryAdapterString
 [getGPURAM]
 Measure=Registry
 RegHKey=HKEY_LOCAL_MACHINE
-RegKey=SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinSat
-RegValue=VideoMemorySize
+RegKey=SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0000
+RegValue=HardwareInformation.qwMemorySize
 
 [measureGPURAM]
 Measure=Calc


### PR DESCRIPTION
Currently the VRAM values for GPUs that carries VRAM over 4GB are displayed incorrectly since the source value is a 32-bit unsigned int. This is a viable fix for that which doesn't break any current functionality of the widget. [Here's the reference from Microsoft](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors).

**Before the fix:**
![image](https://user-images.githubusercontent.com/6711514/100587260-58614980-3316-11eb-997d-1be10e66cae6.png)

**After the fix:**
![image](https://user-images.githubusercontent.com/6711514/100587412-88a8e800-3316-11eb-9c93-cb6950a828a7.png)

